### PR TITLE
Adding Dockerfile, and Production Dockerfile to go-web-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.16.9-buster
+RUN go get -u github.com/beego/bee
+ENV GO111MODULE=on
+ENV GOFLAGS=-mod=vendor
+ENV APP_USER app
+ENV APP_HOME /go/src
+ARG GROUP_ID
+ARG USER_ID
+RUN groupadd --gid $GROUP_ID app && useradd -m -l --uid $USER_ID --gid $GROUP_ID $APP_USER
+RUN mkdir -p $APP_HOME && chown -R $APP_USER:$APP_USER $APP_HOME
+USER $APP_USER
+WORKDIR $APP_HOME
+EXPOSE 3030
+CMD ["bee", "run"]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,21 @@
+FROM golang:1.16.9-buster as builder
+ENV APP_USER app
+ENV APP_HOME /go/src
+RUN groupadd $APP_USER && useradd -m -g $APP_USER -l $APP_USER
+RUN mkdir -p $APP_HOME && chown -R $APP_USER:$APP_USER $APP_HOME
+WORKDIR $APP_HOME
+USER $APP_USER
+COPY go.mod main.go ./
+RUN go mod download
+RUN go mod verify
+RUN go build -o fullscript-web
+FROM golang:1.16.9-buster
+ENV APP_USER app
+ENV APP_HOME /go/src
+RUN groupadd $APP_USER && useradd -m -g $APP_USER -l $APP_USER
+RUN mkdir -p $APP_HOME
+WORKDIR $APP_HOME
+COPY --chown=0:0 --from=builder $APP_HOME $APP_HOME
+EXPOSE 3030
+USER $APP_USER
+CMD ["./fullscript-web"]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ Please write it as if the container will be used in production.
 It exposes a web server on port 3030 and logs to STDOUT.  The port is configurable by setting the PORT environment variable.  
 
 It has several routes that return status code 200 and some data: `/health`, `/hello`, and `/keyword`. All other routes will return 404: "404 page not found".  
+
+## Developer Notes
+There are 2 docker files within this repository:
+1) `Dockerfile` - can be used to run a development environment on port 3030 - which will be linked to a local filestore and watch for any changes.
+    *) To build this image: `docker build --build-arg USER_ID=1000 --build-arg GROUP_ID=1000 -t fullscript/go .`
+        *) Where USER_ID and GROUP_ID are to ensure that the containers in the process are not running as root (if on linux can replace 1000 with `$(id- u)` and `$(id -g)` respectively).
+    *) Once built to run this image: 
+        *) Linux: `docker run -it --rm -p 3030:3030 -v $(pwd):/go/src fullscript/go`  
+        *) PowerShell : `docker run -it --rm -p 3030:3030 -v ${PWD}:/go/src fullscript/go`
+2) `Dockerfile.production` - can used to run a production environment on port 3030
+    *) To build: `docker build -t fullscript/go-production -f .\Dockerfile.production .`
+    *) To run: `docker run -it -p 3030:3030 fullscript/go-production`
+
+## Keyword
+The reponse from `/keyword` is `wellness`.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ It has several routes that return status code 200 and some data: `/health`, `/he
 
 ## Developer Notes
 There are 2 docker files within this repository:
-1) `Dockerfile` - can be used to run a development environment on port 3030 - which will be linked to a local filestore and watch for any changes.
-    *) To build this image: `docker build --build-arg USER_ID=1000 --build-arg GROUP_ID=1000 -t fullscript/go .`
-        *) Where USER_ID and GROUP_ID are to ensure that the containers in the process are not running as root (if on linux can replace 1000 with `$(id- u)` and `$(id -g)` respectively).
-    *) Once built to run this image: 
-        *) Linux: `docker run -it --rm -p 3030:3030 -v $(pwd):/go/src fullscript/go`  
-        *) PowerShell : `docker run -it --rm -p 3030:3030 -v ${PWD}:/go/src fullscript/go`
-2) `Dockerfile.production` - can used to run a production environment on port 3030
-    *) To build: `docker build -t fullscript/go-production -f .\Dockerfile.production .`
-    *) To run: `docker run -it -p 3030:3030 fullscript/go-production`
+1. `Dockerfile` - can be used to run a development environment on port 3030 - which will be linked to a local filestore and watch for any changes.
+    * To build this image: `docker build --build-arg USER_ID=1000 --build-arg GROUP_ID=1000 -t fullscript/go .`
+        * Where USER_ID and GROUP_ID are to ensure that the containers in the process are not running as root (if on linux can replace 1000 with `$(id- u)` and `$(id -g)` respectively).
+    * Once built to run this image: 
+        * Linux: `docker run -it --rm -p 3030:3030 -v $(pwd):/go/src fullscript/go`  
+        * PowerShell : `docker run -it --rm -p 3030:3030 -v ${PWD}:/go/src fullscript/go`
+2. `Dockerfile.production` - can used to run a production environment on port 3030
+    * To build: `docker build -t fullscript/go-production -f .\Dockerfile.production .`
+    * To run: `docker run -it -p 3030:3030 fullscript/go-production`
 
 ## Keyword
 The reponse from `/keyword` is `wellness`.


### PR DESCRIPTION
PR to add 2 new Dockerfiles, one for Developers, and one for running in Production. 

Also updated Readme on Dockerfile use.
